### PR TITLE
add TLS match flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,5 @@ The mask flags are as follows:
 * `a` - only match users *with* an account
 * `A` - only match users *without* an account
 * `N` - also match on nick changes instead of just on connections
+* `z` - only match users who *are* using TLS
+* `Z` - only match users who *are not* using TLS

--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -150,6 +150,11 @@ class Server(BaseServer):
         else:
             uflags.add("A")
 
+        if user.secure:
+            uflags.add("z")
+        else:
+            uflags.add("Z")
+
         if event == Event.CONNECT:
             uflags.add("n")
 
@@ -269,6 +274,12 @@ class Server(BaseServer):
 
             if nick in self._users:
                 self._users[nick].account = account
+
+        elif line.command == RPL_WHOISSECURE:
+            nick = line.params[1]
+
+            if nick in self._users:
+                self._users[nick].secure = True
 
         elif line.command == RPL_ENDOFWHOIS:
             nick = line.params[1]

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -12,6 +12,7 @@ class User(object):
     real: str
     ip: Optional[str]
     account: Optional[str] = None
+    secure: bool = False
 
     connected: bool = True
 


### PR DESCRIPTION
Similar to account flags, `Z` will match insecure connections and `z` will match secure connections.