### PR TITLE
add 'KILL' mask type

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ adds a reason template that can be used in mask reasons (see above example)
 Prints a line to channel configured in `config.yaml` to tell you that someone
 matched the pattern.
 
+### KILL
+
+Same as `WARN`, but also issues a `/kill` for the user.
+
 ### LETHAL
 
 Same as `WARN`, but also k-lines the user.

--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -212,7 +212,7 @@ class Server(BaseServer):
             types   = {d.type for i, (m, d) in matches}
 
             # sort by mask type, descending
-            # this should order: exclude, dlethal, lethal, warn
+            # this should order: exclude, dlethal, lethal, kill, warn
             matches.sort(
                 key=lambda m: mask_weight(m[1][1].type),
                 reverse=True
@@ -241,6 +241,9 @@ class Server(BaseServer):
                 await self.send_raw(ban)
             elif d.type == MaskType.DLETHAL:
                 self.delayed_send.append((monotonic(), ban))
+            elif d.type == MaskType.KILL:
+                public_reason, *_ = reason.split("|", 1)
+                await self.send(build("KILL", [nick, public_reason]))
 
             if (d.type == MaskType.EXCLUDE and
                     len(types) == 1):

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -17,14 +17,16 @@ class User(object):
     connected: bool = True
 
 class MaskType(IntEnum):
-    WARN    = 0b0001
-    LETHAL  = 0b0010
-    EXCLUDE = 0b0100
-    DELAYED = 0b1000
-    DLETHAL = 0b1010
+    WARN    = 0b00001
+    LETHAL  = 0b00010
+    EXCLUDE = 0b00100
+    DELAYED = 0b01000
+    DLETHAL = 0b01010
+    KILL    = 0b10000
 
 MASK_SORT = [
     MaskType.WARN,
+    MaskType.KILL,
     MaskType.LETHAL,
     MaskType.DLETHAL,
     MaskType.EXCLUDE


### PR DESCRIPTION
this also reassigns mask type numbers so existing databases will be invalid, but this time I put space between mask type numbers so we've got wiggle room in the future