### PR TITLE
support ^ and $ in string literal flags, to anchor the string left/right

### DIFF
--- a/bismite/common.py
+++ b/bismite/common.py
@@ -61,6 +61,10 @@ def mask_compile(
     mask = mask[1:]
     if delimiter in {"\"", "'"}:
         mask = re.escape(mask)
+        if "^" in flags:
+            mask = f"^{mask}"
+        if "$" in flags:
+            mask = f"{mask}$"
 
     return re.compile(mask, rflags), flags
 


### PR DESCRIPTION
e.g. `ADDMASK "asd*"$ foo` translates to the regex `asd\*$`