### PR TITLE
make mask type order distinct from saved values

### DIFF
--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -208,7 +208,10 @@ class Server(BaseServer):
 
             # sort by mask type, descending
             # this should order: exclude, dlethal, lethal, warn
-            matches.sort(key=lambda m: m[1][1].type, reverse=True)
+            matches.sort(
+                key=lambda m: mask_weight(m[1][1].type),
+                reverse=True
+            )
 
             mask_id, (mask, d) = matches[0]
 

--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -18,7 +18,7 @@ from .config   import Config
 from .database import Database
 
 from .common   import Event, MaskType, User, to_pretty_time
-from .common   import mask_compile, mask_find, mask_token
+from .common   import mask_compile, mask_find, mask_token, mask_weight
 
 # not in ircstates yet...
 RPL_RSACHALLENGE2      = "740"

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -17,10 +17,19 @@ class User(object):
     connected: bool = True
 
 class MaskType(IntEnum):
-    WARN    = 1
-    LETHAL  = 2
-    DLETHAL = 3
-    EXCLUDE = 4
+    WARN    = 0b0001
+    LETHAL  = 0b0010
+    EXCLUDE = 0b0100
+    DLETHAL = 0b1000
+
+MASK_SORT = [
+    MaskType.WARN,
+    MaskType.LETHAL,
+    MaskType.DLETHAL,
+    MaskType.EXCLUDE
+]
+def mask_weight(mtype: MaskType) -> int:
+    return MASK_SORT.index(mtype)
 
 class Event(Enum):
     CONNECT = 1

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -20,7 +20,8 @@ class MaskType(IntEnum):
     WARN    = 0b0001
     LETHAL  = 0b0010
     EXCLUDE = 0b0100
-    DLETHAL = 0b1000
+    DELAYED = 0b1000
+    DLETHAL = 0b1010
 
 MASK_SORT = [
     MaskType.WARN,


### PR DESCRIPTION
did this to future proof `MaskType` values, so we shouldn't need to make databases broken if we add/change mask types.

this PR does break current `DLETHAL`  masks, but I also made this bitmaskable  because in the future I'd like to kill `DLETHAL` in favour of `SETMASK 1 lethal delayed` which would end up being `MaskType.LETHAL|MaskType.DELAYED`