### PR TITLE
offer bancmd $reason also as $user_reason and $oper_reason

### DIFF
--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -230,10 +230,14 @@ class Server(BaseServer):
                 "mask_id": str(mask_id)
             })
 
+            user_reason, _, oper_reason = reason.partition("|")
+
             info = {
-                "ident": ident,
-                "user": user,
-                "reason": reason
+                "ident":  ident,
+                "user":   user,
+                "reason": reason,
+                "user_reason": user_reason,
+                "oper_reason": oper_reason
             }
 
             ban = self._config.bancmd.format(**info)

--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -246,8 +246,7 @@ class Server(BaseServer):
             elif d.type == MaskType.DLETHAL:
                 self.delayed_send.append((monotonic(), ban))
             elif d.type == MaskType.KILL:
-                public_reason, *_ = reason.split("|", 1)
-                await self.send(build("KILL", [nick, public_reason]))
+                await self.send(build("KILL", [nick, user_reason]))
 
             if (d.type == MaskType.EXCLUDE and
                     len(types) == 1):


### PR DESCRIPTION
some IRCds don't support k-line/g-line `|oper reason` so giving them `$user_reason` to only use the user-facing reason is good