### PR TITLE
change mask types: first 4 bits are action, rest is a modifier bitmask

### DIFF
--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -537,12 +537,13 @@ class Server(BaseServer):
         else:
             who = f"{nick}"
 
+        mtype_str = mtype_tostring(d.type)
         out = (
             f"{who} TOGGLEMASK: {enabled_s}"
-            f" {d.type.name} mask \x02{mask}\x02"
+            f" {mtype_str} mask \x02{mask}\x02"
         )
         await self.send(build("PRIVMSG", [self._config.channel, out]))
-        return [f"{d.type.name} mask {mask_id} {enabled_s}"]
+        return [f"{mtype_str} mask {mask_id} {enabled_s}"]
 
     @usage("<id> <type>")
     async def cmd_setmask(self, oper: Optional[str], nick: str, sargs: str):

--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -17,8 +17,9 @@ from ircchallenge         import Challenge
 from .config   import Config
 from .database import Database
 
-from .common   import Event, MaskType, User, to_pretty_time
-from .common   import mask_compile, mask_find, mask_token, mask_weight
+from .common   import Event, MaskAction, MaskModifier, User, to_pretty_time
+from .common   import (mask_compile, mask_find, mask_token, mtype_weight,
+    mtype_tostring, mtype_fromstring)
 
 # not in ircstates yet...
 RPL_RSACHALLENGE2      = "740"
@@ -217,11 +218,12 @@ class Server(BaseServer):
             # sort by mask type, descending
             # this should order: exclude, dlethal, lethal, kill, warn
             matches.sort(
-                key=lambda m: mask_weight(m[1][1].type),
+                key=lambda m: mtype_weight(m[1][1].type),
                 reverse=True
             )
 
             mask_id, (mask, d) = matches[0]
+            mtype_action       = mtype_action(d.type)
 
             ident  = user.user
             # if the user doesn't have identd, bin the whole host
@@ -244,24 +246,30 @@ class Server(BaseServer):
                 "oper_reason": oper_reason
             }
 
-            ban = self._config.bancmd.format(**info)
-            if d.type == MaskType.LETHAL:
-                await self.send_raw(ban)
-            elif d.type == MaskType.DLETHAL:
-                self.delayed_send.append((monotonic(), ban))
-            elif d.type == MaskType.KILL:
-                await self.send(build("KILL", [nick, user_reason]))
+            action: Optional[str] = None
+            if   mtype_action == MaskType.LETHAL:
+                action = self._config.bancmd.format(**info)
+            elif mtype_action == MaskType.KILL:
+                action = f"KILL {nick} :{user_reason}"
 
-            if (d.type == MaskType.EXCLUDE and
+            if action is None:
+                pass
+            elif d.type & MaskModifier.DELAYED:
+                self.delayed_send.append((monotonic(), action))
+            else:
+                await self.send_raw(action)
+
+            if (mtype_action == MaskType.EXCLUDE and
                     len(types) == 1):
                 # we matched an EXCLUDE but no other types.
                 # do not log
                 pass
-            else:
+            elif not d.type & MaskModifier.SILENT:
+                mtype_str = mtype_tostring(d.type)
                 await self.send(build("PRIVMSG", [
                     self._config.channel,
                     (
-                        f"MASK: {d.type.name} mask {mask_id} "
+                        f"MASK: {mtype_str} mask {mask_id} "
                         f"{nick}!{user.user}@{user.host} {user.real}"
                     )
                 ]))
@@ -418,11 +426,12 @@ class Server(BaseServer):
             last_hit = to_pretty_time(int(time()-details.last_hit))
             last_hit = f", last hit {last_hit} ago"
 
+        mtype_str = mtype_tostring(details.type)
         return (
             f"{str(mask_id).rjust(3)}:"
             f" \x02{mask}\x02"
             f" ({details.hits} hits{last_hit})"
-            f" \x02{details.type.name}\x02"
+            f" \x02{mtype_str}\x02"
             f" [{details.reason or ''}]"
         )
 
@@ -537,33 +546,37 @@ class Server(BaseServer):
 
     @usage("<id> <type>")
     async def cmd_setmask(self, oper: Optional[str], nick: str, sargs: str):
-        args   = sargs.split()
-        mtypes = {m.name for m in MaskType}
+        args = sargs.split()
         if len(args) < 2:
             raise UsageError("not enough params")
         elif not args[0].isdigit():
             raise UsageError("that's not an id/number")
-        elif not args[1].upper() in mtypes:
-            return [f"mask type must be one of {mtypes!r}"]
 
-        mask_id   = int(args[0])
-        mask_type = MaskType[args[1].upper()]
+        mask_id = int(args[0])
         if not await self._database.masks.has_id(mask_id):
             return [f"unknown mask id {mask_id}"]
 
-        mask, d = await self._database.masks.get(mask_id)
-        if d.type == mask_type:
-            return [f"{mask} is already {mask_type.name}"]
+        try:
+            mtype = mtype_fromstring(args[1])
+        except ValueError as e:
+            raise UsageError(str(e))
+
+        mtype_str = mtype_tostring(mtype)
+        mask, d   = await self._database.masks.get(mask_id)
+        if d.type == mtype:
+            return [f"{mask} is already \2{mtype_str}\2"]
         if oper is not None:
             who = f"{nick} ({oper})"
         else:
             who = f"{nick}"
-        await self._database.masks.set_type(nick, oper, mask_id, mask_type)
+        await self._database.masks.set_type(nick, oper, mask_id, mtype)
 
-        log = f"{who} SETMASK: type {mask_type.name} \x02{mask}\x02 (was {d.type.name})"
+        # *p*revious mtype_str
+        pmtype_str = mtype_tostring(d.type)
+        log = f"{who} SETMASK: type {mtype_str} \x02{mask}\x02 (was {pmtype_str})"
         await self.send(build("PRIVMSG", [self._config.channel, log]))
 
-        return [f"{mask} changed from {d.type.name} to {mask_type.name}"]
+        return [f"{mask} changed from \2{pmtype_str}\2 to \2{mtype_str}\2"]
 
     async def cmd_listmask(self, oper: Optional[str], nick: str, args: str):
         outs: List[str] = []

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -17,9 +17,9 @@ class User(object):
     connected: bool = True
 
 class MaskAction(IntEnum):
+    KILL    = 0
     WARN    = 1
     LETHAL  = 2
-    KILL    = 3
     EXCLUDE = 4
 class MaskModifier(IntFlag):
     NONE   = 0

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -26,7 +26,7 @@ class MaskModifier(IntFlag):
     DELAY  = 0b001 << 4
     SILENT = 0b010 << 4
 
-def mtype_action(
+def mtype_getaction(
         mtype: int
         ) -> MaskAction:
     action = mtype & 0xf # get lowest 4 bits
@@ -49,7 +49,7 @@ def mtype_fromstring(mstr: str) -> int:
     return mtype
 
 def mtype_tostring(mtype: int) -> str:
-    action = mtype_action(mtype)
+    action = mtype_getaction(mtype)
     parts: List[str] = [action.name]
 
     if mtype & MaskModifier.DELAY:
@@ -66,7 +66,7 @@ MASK_SORT = [
 ]
 def mtype_weight(mtype: int) -> int:
     # split action and modifiers
-    action    = mtype_action(mtype)
+    action    = mtype_getaction(mtype)
     modifiers = mtype>>4
     # get maximum modifier bit count so we know how far left
     # we need to bitshift `action`

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -65,7 +65,9 @@ MASK_SORT = [
     MaskAction.EXCLUDE
 ]
 def mtype_weight(mtype: int) -> int:
-    action, modifier = mask_split(mtype)
+    # split action and modifiers
+    action    = mtype_action(mtype)
+    modifiers = mtype>>4
     # get maximum modifier bit count so we know how far left
     # we need to bitshift `action`
     modifier_offset  = max(MaskModifier).value.bit_length()
@@ -75,7 +77,7 @@ def mtype_weight(mtype: int) -> int:
     # LETHAL|NONE, LETHAL|DELAY, EXCLUDE|NONE
     # and rewrite action by MASK_SORT weight so it'll sort as
     # EXCLUDE|NONE, LETHAL|DELAY, LETHAL|NONE
-    return (MASK_SORT.index(action)<<modifier_offset) + modifier
+    return (MASK_SORT.index(action)<<modifier_offset) + modifiers
 
 class Event(Enum):
     CONNECT = 1


### PR DESCRIPTION
I hope this is the last time I change my mind on how to store mask types!

this solution keeps mask type as a single int, but it uses the lowest 4 bits as an action (16 possible actions) and uses any bits higher than that as a bitmask of modifiers. the idea here is that actions are mutually exclusive (you can't do `WARN` and `LETHAL`  on the same mask) so they don't need to be a bitmask, but modifiers are not mutually exclusive.

because I can't see us ever needing more than 16 actions, it's fine to keep those as the lowest bits, and leave the rest indefinitely expandable if/when we add new modifiers.

this PR also changes `SETMASK` to accept `ACTION|MODIFIER-1|MODIFIER-2` e.g. `LETHAL|SILENT|DELAY`. this will again make current `DLETHAL` masks invalid, and will make `KILL` masks invalid

I think the most confusing part of this change is `mtype_weight()` but I've put some comments there to explain the logic