### PR TITLE
implement mask expiry

### DIFF
--- a/bismite/__init__.py
+++ b/bismite/__init__.py
@@ -587,6 +587,9 @@ class Server(BaseServer):
                     expire = int(time()) + expire
 
                 await self._database.masks.set_expire(mask_id, expire)
+                await self._database.changes.add(
+                    mask_id, caller.source, caller.oper, f"expire {timespec}"
+                )
                 outs.append(f"{mask} expiry set to {timespec}")
             else:
                 raise UsageError("expiry must be in format +1w2d/~1w2d")

--- a/bismite/__main__.py
+++ b/bismite/__main__.py
@@ -3,12 +3,14 @@ from argparse import ArgumentParser
 
 from ircrobots import ConnectionParams, SASLUserPass
 
-from .       import Bot
-from .config import Config, load as config_load
-from .timers import delayed_send, delayed_check
+from .         import Bot
+from .config   import Config, load as config_load
+from .database import Database
+from .timers   import delayed_send, delayed_check, expire_masks
 
 async def main(config: Config):
-    bot = Bot(config)
+    db  = Database(config.database)
+    bot = Bot(config, db)
 
     host, port, tls      = config.server
     sasl_user, sasl_pass = config.sasl
@@ -28,6 +30,7 @@ async def main(config: Config):
     await asyncio.wait([
         delayed_send(bot),
         delayed_check(bot),
+        expire_masks(bot, db),
         bot.run()
     ])
 

--- a/bismite/common.py
+++ b/bismite/common.py
@@ -84,14 +84,6 @@ class Event(Enum):
     CONNECT = 1
     NICK    = 2
 
-@dataclass
-class MaskDetails(object):
-    type:     int
-    enabled:  bool
-    reason:   Optional[str]
-    hits:     int
-    last_hit: Optional[int]
-
 def _unescape(input: str, char: str):
     i   = 0
     out = ""
@@ -231,3 +223,15 @@ def to_pretty_time(total_seconds: int) -> str:
         out += f"{i}{unit}"
     return out
 
+RE_PRETTYTIME = re.compile("^(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?$")
+def from_pretty_time(s: str) -> Optional[int]:
+    match = RE_PRETTYTIME.search(s)
+    if match and match.group(0):
+        seconds  = 0
+        seconds += int(match.group(1) or "0") * SECONDS_WEEKS
+        seconds += int(match.group(2) or "0") * SECONDS_DAYS
+        seconds += int(match.group(3) or "0") * SECONDS_HOURS
+        seconds += int(match.group(4) or "0") * SECONDS_MINUTES
+        return seconds
+    else:
+        return None

--- a/bismite/timers.py
+++ b/bismite/timers.py
@@ -97,6 +97,7 @@ async def expire_masks(
                 )
             else:
                 # downgrade to disabled
+                await db.masks.set_expire(None)
                 await db.masks.toggle(source, '', mask_id)
                 del server.active_masks[mask_id]
                 await server.report(

--- a/bismite/timers.py
+++ b/bismite/timers.py
@@ -92,13 +92,15 @@ async def expire_masks(
             if mtype_action in {MaskAction.KILL, MaskAction.LETHAL}:
                 # downgrade to WARN
                 await db.masks.set_type(source, '', mask_id, MaskAction.WARN)
+                await db.changes.add(mask_id, source, '', "expire to WARN")
                 await server.report(
                     f"MASK:EXPIRE: \x02{mask}\x02 {mtype_str} -> WARN"
                 )
             else:
                 # downgrade to disabled
-                await db.masks.set_expire(None)
-                await db.masks.toggle(source, '', mask_id)
+                await db.masks.set_expire(mask_id, None)
+                await db.masks.toggle(mask_id)
+                await db.changes.add(mask_id, source, '', "expire")
                 del server.active_masks[mask_id]
                 await server.report(
                     f"MASK:EXPIRE: \x02{mask}\x02 {mtype_str}"

--- a/bismite/timers.py
+++ b/bismite/timers.py
@@ -1,6 +1,6 @@
-import asyncio, re, time
+import asyncio, re
 from datetime import datetime
-from time     import monotonic
+from time     import monotonic, time
 from typing   import List, Optional, Tuple
 
 from irctokens import build
@@ -9,7 +9,7 @@ from ircrobots import Bot, Server
 from ircstates.numerics import *
 from ircrobots.matching import ANY, Folded, Response, SELF
 
-from .common   import Event
+from .common   import Event, mtype_getaction, mtype_tostring, MaskAction
 from .database import Database
 
 SEND_DELAY = 10.0
@@ -52,5 +52,55 @@ async def delayed_check(
                 else:
                     wait = due-now
                     break
+
+        await asyncio.sleep(wait)
+
+async def expire_masks(
+        bot: Bot,
+        db:  Database):
+
+    while True:
+        now  = int(time())
+        wait = 60.0
+
+        if not bot.servers:
+            await asyncio.sleep(wait)
+            continue
+
+        server = list(bot.servers.values())[0]
+        source = f"{server.nickname}!{server.username}@{server.hostname}"
+        for mask_id in list(server.active_masks.keys()):
+            mask, details = await db.masks.get(mask_id)
+
+            if details.expire is None:
+                # no expiry
+                continue
+            elif details.expire < 0:
+                # expire relative to last hit time
+                expire = details.last_hit + abs(details.expire)
+            else:
+                expire = details.expire
+
+            if expire > now:
+                # not yet expired
+                wait = min(wait, expire-now)
+                continue
+
+            # has expired
+            mtype_action = mtype_getaction(details.type)
+            mtype_str    = mtype_tostring(details.type)
+            if mtype_action in {MaskAction.KILL, MaskAction.LETHAL}:
+                # downgrade to WARN
+                await db.masks.set_type(source, '', mask_id, MaskAction.WARN)
+                await server.report(
+                    f"MASK:EXPIRE: \x02{mask}\x02 {mtype_str} -> WARN"
+                )
+            else:
+                # downgrade to disabled
+                await db.masks.toggle(source, '', mask_id)
+                del server.active_masks[mask_id]
+                await server.report(
+                    f"MASK:EXPIRE: \x02{mask}\x02 {mtype_str}"
+                )
 
         await asyncio.sleep(wait)

--- a/make-database.sql
+++ b/make-database.sql
@@ -5,9 +5,10 @@ CREATE TABLE masks (
     mask     TEXT NOT NULL,
     type     INTEGER NOT NULL,
     enabled  INTEGER NOT NULL,
+    expire   INTEGER,
     reason   TEXT,
     hits     INTEGER NOT NULL,
-    last_hit INTEGER
+    last_hit INTEGER NOT NULL
 );
 CREATE TABLE changes (
     mask_id   INTEGER NOT NULL,


### PR DESCRIPTION
closes #1

supports two formats of expiration:

`SETMASK 1 ~1h lethal`
`SETMASK 1 +1h lethal`

`~1h` means `"expire one hour from now"`
`+1h` means `"expire one hour after the last hit"`

`KILL` and `LETHAL` masks will expire in 2 steps. the first expiry will degrade them to a `WARN` and the second will disable them, for a total of twice the expiry you specify.